### PR TITLE
Added support to JPEG2000 on AFURLResponseSerialization

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AFNetworking'
-  s.version  = '3.2.1'
+  s.version  = '3.2.1.1'
   s.license  = 'MIT'
   s.summary  = 'A delightful iOS and OS X networking framework.'
   s.homepage = 'https://github.com/AFNetworking/AFNetworking'

--- a/AFNetworking/AFURLResponseSerialization.h
+++ b/AFNetworking/AFURLResponseSerialization.h
@@ -223,6 +223,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  - `image/tiff`
  - `image/jpeg`
+ - `image/jp2`
  - `image/gif`
  - `image/png`
  - `image/ico`

--- a/AFNetworking/AFURLResponseSerialization.m
+++ b/AFNetworking/AFURLResponseSerialization.m
@@ -565,7 +565,7 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
 
     if ([response.MIMEType isEqualToString:@"image/png"]) {
         imageRef = CGImageCreateWithPNGDataProvider(dataProvider,  NULL, true, kCGRenderingIntentDefault);
-    } else if ([response.MIMEType isEqualToString:@"image/jpeg"]) {
+    } else if ([response.MIMEType isEqualToString:@"image/jpeg"] || [response.MIMEType isEqualToString:@"image/jp2"]) {
         imageRef = CGImageCreateWithJPEGDataProvider(dataProvider, NULL, true, kCGRenderingIntentDefault);
 
         if (imageRef) {
@@ -657,7 +657,7 @@ static UIImage * AFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *r
         return nil;
     }
 
-    self.acceptableContentTypes = [[NSSet alloc] initWithObjects:@"image/tiff", @"image/jpeg", @"image/gif", @"image/png", @"image/ico", @"image/x-icon", @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
+    self.acceptableContentTypes = [[NSSet alloc] initWithObjects:@"image/tiff", @"image/jpeg", @"image/jp2", @"image/gif", @"image/png", @"image/ico", @"image/x-icon", @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
 
 #if TARGET_OS_IOS || TARGET_OS_TV
     self.imageScale = [[UIScreen mainScreen] scale];

--- a/Tests/Tests/AFImageDownloaderTests.m
+++ b/Tests/Tests/AFImageDownloaderTests.m
@@ -198,7 +198,20 @@
     [self waitForExpectationsWithCommonTimeout];
     XCTAssertNotNil(urlResponse);
     XCTAssertNotNil(responseImage);
+}
 
+- (void)testThatItCanDownloadAndSerializeJP2Images {
+    NSString *imageURLString = @"https://github.com/bitsgalore/jp2kMagic/blob/master/sampleImages/balloon.jp2?raw=true";
+    XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"Request %@ should succeed", imageURLString]];
+    [self.downloader
+     downloadImageForURLRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:imageURLString]]
+     success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull responseObject) {
+         [expectation fulfill];
+         XCTAssertNotNil(responseObject);
+     } failure:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, NSError * _Nonnull error) {
+         XCTFail(@"Request %@ failed with error %@", request, error);
+     }];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 #pragma mark - Caching


### PR DESCRIPTION
# What

* This PR adds JPEG2000 support to AFNetworking
* Added some end-to-end UT to make sure that we can request and serialize the image

# Future Work

* I'll make this PR to the official AFNetworking as well, since iOS supports `jp2`for a while now