### PR TITLE
Fixed issue with AFImageDownloader that was not properly setting HTTP headers on UIImage requests

### DIFF
--- a/AFNetworking.podspec
+++ b/AFNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AFNetworking'
-  s.version  = '3.2.1.1'
+  s.version  = '3.2.1.2'
   s.license  = 'MIT'
   s.summary  = 'A delightful iOS and OS X networking framework.'
   s.homepage = 'https://github.com/AFNetworking/AFNetworking'

--- a/Tests/Tests/AFUIImageViewTests.m
+++ b/Tests/Tests/AFUIImageViewTests.m
@@ -169,6 +169,40 @@
 
 }
 
+- (void)testThatSessionHTTPHeaderAreProperlySetOnRequest {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Request with proper HTTP Headers"];
 
+    __block NSURLRequest *successRequest;
+    __block NSHTTPURLResponse *successResponse;
+    __block UIImage *successImage;
+    __block NSError *successError;
+
+    [self.imageView setImageWithURLRequest:self.jpegURLRequest
+                          placeholderImage:nil
+                                   success:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, UIImage * _Nonnull image) {
+                                       successRequest = request;
+                                       successResponse = response;
+                                       successImage = image;
+                                       [expectation fulfill];
+                                   } failure:^(NSURLRequest * _Nonnull request, NSHTTPURLResponse * _Nullable response, NSError * _Nonnull error) {
+                                       successRequest = request;
+                                       successResponse = response;
+                                       successError = error;
+                                       [expectation fulfill];
+                                   }];
+
+    [self waitForExpectationsWithCommonTimeout];
+    XCTAssertNotNil(successRequest);
+    XCTAssertNotNil(successResponse);
+    XCTAssertNotNil(successImage);
+    XCTAssertNil(successError);
+
+    AFHTTPRequestSerializer *requestSerializer = [UIImageView sharedImageDownloader].sessionManager.requestSerializer;
+
+    XCTAssertTrue(requestSerializer.HTTPRequestHeaders.count > 0);
+    XCTAssertNil(self.jpegURLRequest.allHTTPHeaderFields[@"User-Agent"]);
+    XCTAssertNotNil(successRequest.allHTTPHeaderFields[@"User-Agent"]);
+    XCTAssertEqual(successRequest.allHTTPHeaderFields[@"User-Agent"], requestSerializer.HTTPRequestHeaders[@"User-Agent"]);
+}
 
 @end

--- a/UIKit+AFNetworking/UIImageView+AFNetworking.h
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.h
@@ -87,6 +87,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  If a success block is specified, it is the responsibility of the block to set the image of the image view before returning. If no success block is specified, the default behavior of setting the image with `self.image = image` is applied.
 
+ Note that the NSURLRequest retrieved by the completion blocks can be different from the original request, since it can be mutated to inject the current HTTP Headers in the configured requestSerializer
+
  @param urlRequest The URL request used for the image request.
  @param placeholderImage The image to be set initially, until the image request finishes. If `nil`, the image view will not change its image until the image request finishes.
  @param success A block to be executed when the image data task finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the image created from the response data of request. If the image was returned from cache, the response parameter will be `nil`.


### PR DESCRIPTION
# What

* When we were making image requests using `UIImageView+AFNetworking`, we were never sending the properly configured `User-Agent`
* After some investigation, I found out that this was because we were ignoring the current session HTTP Headers since we are already providing a `NSURLRequest`
* This PR starts using the same method being used by other request on `AFNetworking` to mutate the `NSURLRequest` adding all the needed fields

# Future work

* I'll integrate this version on the app, making sure that we are not actually comparing the request pointers but the actual request URL
* I'll probably open this PR to the main `AFNetworking` repo as well